### PR TITLE
Fix a bug in learning rate scheduler for triplet loss

### DIFF
--- a/docs/examples/benchmarks.rst
+++ b/docs/examples/benchmarks.rst
@@ -25,10 +25,10 @@ CUHK03
    ========= ============ ======== ============ ========== ============== ===============
    Inception Triplet      N/A      N/A          N/A        N/A            N/A
    Inception CrossEntropy 65.8     48.6         73.2       71.0           ``python examples/inception.py -d cuhk03 --combine-trainval --loss xentropy --logs-dir examples/logs/inception-cuhk03-xentropy``
-   Inception OIM          71.4     56.0         **77.7**   76.5           ``python examples/inception.py -d cuhk03 --combine-trainval --loss oim --oim-scalar 20 --logs-dir examples/logs/inception-cuhk03-oim``
-   ResNet-50 Triplet      69.8     53.0         76.1       76.0           ``python examples/resnet.py -d cuhk03 --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0001 --epochs 150 --logs-dir examples/logs/resnet-cuhk03-triplet``
+   Inception OIM          71.4     56.0         77.7       76.5           ``python examples/inception.py -d cuhk03 --combine-trainval --loss oim --oim-scalar 20 --logs-dir examples/logs/inception-cuhk03-oim``
+   ResNet-50 Triplet      **80.7** **67.9**     **84.3**   **85.0**       ``python examples/resnet.py -d cuhk03 --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0002 --epochs 150 --logs-dir examples/logs/resnet-cuhk03-triplet``
    ResNet-50 CrossEntropy 62.7     44.6         70.8       69.0           ``python examples/resnet.py -d cuhk03 --combine-trainval --loss xentropy --lr 0.1 --logs-dir examples/logs/resnet-cuhk03-xentropy``
-   ResNet-50 OIM          **72.5** **58.2**     77.5       **79.2**       ``python examples/resnet.py -d cuhk03 --combine-trainval --loss oim --oim-scalar 30 --logs-dir examples/logs/resnet-cuhk03-oim``
+   ResNet-50 OIM          72.5     58.2         77.5       79.2           ``python examples/resnet.py -d cuhk03 --combine-trainval --loss oim --oim-scalar 30 --logs-dir examples/logs/resnet-cuhk03-oim``
    ========= ============ ======== ============ ========== ============== ===============
 
 .. _market1501-benchmark:
@@ -43,9 +43,9 @@ Market1501
    Inception Triplet      N/A      N/A          N/A        N/A            N/A
    Inception CrossEntropy 51.8     26.8         57.1       75.8           ``python examples/inception.py -d market1501 --combine-trainval --loss xentropy --logs-dir examples/logs/inception-market1501-xentropy``
    Inception OIM          54.3     30.1         58.3       77.9           ``python examples/inception.py -d market1501 --combine-trainval --loss oim --oim-scalar 20 --logs-dir examples/logs/inception-market1501-oim``
-   ResNet-50 Triplet      56.9     31.3         60.5       78.6           ``python examples/resnet.py -d market1501 --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0001 --epochs 150 --logs-dir examples/logs/resnet-market1501-triplet``
+   ResNet-50 Triplet      **67.9** **42.9**     **70.5**   **85.1**       ``python examples/resnet.py -d market1501 --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0002 --epochs 150 --logs-dir examples/logs/resnet-market1501-triplet``
    ResNet-50 CrossEntropy 59.8     35.5         62.8       81.4           ``python examples/resnet.py -d market1501 --combine-trainval --loss xentropy --lr 0.1 --logs-dir examples/logs/resnet-market1501-xentropy``
-   ResNet-50 OIM          **60.9** **37.3**     **63.6**   **82.1**       ``python examples/resnet.py -d market1501 --combine-trainval --loss oim --oim-scalar 20 --logs-dir examples/logs/resnet-market1501-oim``
+   ResNet-50 OIM          60.9     37.3         63.6       82.1           ``python examples/resnet.py -d market1501 --combine-trainval --loss oim --oim-scalar 20 --logs-dir examples/logs/resnet-market1501-oim``
    ========= ============ ======== ============ ========== ============== ===============
 
 .. _dukemtmc-benchmark:
@@ -60,13 +60,12 @@ DukeMTMC
    Inception Triplet      N/A      N/A          N/A        N/A            N/A
    Inception CrossEntropy 34.0     17.4         39.2       54.4           ``python examples/inception.py -d dukemtmc --combine-trainval --loss xentropy --logs-dir examples/logs/inception-dukemtmc-xentropy``
    Inception OIM          40.6     22.4         45.3       61.7           ``python examples/inception.py -d dukemtmc --combine-trainval --loss oim --oim-scalar 30 --logs-dir examples/logs/inception-dukemtmc-oim``
-   ResNet-50 Triplet      44.8     26.4         47.5       64.8           ``python examples/resnet.py -d dukemtmc --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0001 --epochs 150 --logs-dir examples/logs/resnet-dukemtmc-triplet``
+   ResNet-50 Triplet      **54.6** **34.6**     **57.5**   **73.1**       ``python examples/resnet.py -d dukemtmc --combine-trainval --num-instances 4 --dropout 0 --loss triplet --optimizer adam --lr 0.0002 --epochs 150 --logs-dir examples/logs/resnet-dukemtmc-triplet``
    ResNet-50 CrossEntropy 40.7     23.7         44.3       62.5           ``python examples/resnet.py -d dukemtmc --combine-trainval --loss xentropy --lr 0.1 --logs-dir examples/logs/resnet-dukemtmc-xentropy``
-   ResNet-50 OIM          **47.4** **29.2**     **50.4**   **68.1**       ``python examples/resnet.py -d dukemtmc --combine-trainval --loss oim --oim-scalar 30 --logs-dir examples/logs/resnet-dukemtmc-oim``
+   ResNet-50 OIM          47.4     29.2         50.4       68.1           ``python examples/resnet.py -d dukemtmc --combine-trainval --loss oim --oim-scalar 30 --logs-dir examples/logs/resnet-dukemtmc-oim``
    ========= ============ ======== ============ ========== ============== ===============
 
 .. ATTENTION::
-   We have not yet found the correct ways to train with Triplet loss on these
-   datasets. ResNet-50 results are inferior than [hermans2017in]_ and Inception
-   cannot converge properly. Any comments are welcome on updating these
-   benchmarks.
+   No test-time augmentation is used. We have fixed a bug in the learning rate
+   scheduler for the Triplet loss. Now the result of ResNet-50 with Triplet loss
+   is slightly better than the "original" setting in [hermans2017in]_ (Table 4).

--- a/examples/resnet.py
+++ b/examples/resnet.py
@@ -107,8 +107,12 @@ def main(args):
         model = ResNet(args.depth, pretrained=True, num_features=args.features,
                        norm=True, dropout=args.dropout)
     elif args.loss == 'triplet':
+        # Hack for making the classifier the last feature embedding layer
+        # Net structure: avgpool -> FC(1024) -> FC(args.features)
         model = ResNet(args.depth, pretrained=True,
-                       num_features=args.features, dropout=args.dropout)
+                       num_features=1024,
+                       norm=False, dropout=args.dropout,
+                       num_classes=args.features)
     else:
         raise ValueError("Cannot recognize loss type:", args.loss)
     model = torch.nn.DataParallel(model).cuda()
@@ -178,7 +182,7 @@ def main(args):
             lr = args.lr * (0.1 ** (epoch // 40))
         elif args.optimizer == 'adam':
             lr = args.lr if epoch <= 100 else \
-                args.lr * (0.001 ** (epoch - 100) / 50)
+                args.lr * (0.001 ** ((epoch - 100) / 50))
         else:
             raise ValueError("Cannot recognize optimizer type:", args.optimizer)
         for g in optimizer.param_groups:


### PR DESCRIPTION
Now it achieves slightly better result than Hermans, et al., [reported](https://arxiv.org/pdf/1703.07737.pdf)  under the "original" setting in Table 4.