### PR TITLE
Fix pytorch v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ state-of-the-art results.
 
 ## Installation
 
-Install [PyTorch](http://pytorch.org/) (version >= 0.1.11). Although we support
+Install [PyTorch](http://pytorch.org/) (version >= 0.2.0). Although we support
 both python2 and python3, we recommend python3 for better performance.
 
 ```shell

--- a/reid/evaluation_metrics/classification.py
+++ b/reid/evaluation_metrics/classification.py
@@ -14,6 +14,6 @@ def accuracy(output, target, topk=(1,)):
 
     ret = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].view(-1).float().sum(dim=0, keepdim=True)
         ret.append(correct_k.mul_(1. / batch_size))
     return ret

--- a/reid/evaluators.py
+++ b/reid/evaluators.py
@@ -47,7 +47,7 @@ def pairwise_distance(features, query=None, gallery=None, metric=None):
         x = x.view(n, -1)
         if metric is not None:
             x = metric.transform(x)
-        dist = torch.pow(x, 2).sum(1) * 2
+        dist = torch.pow(x, 2).sum(dim=1, keepdim=True) * 2
         dist = dist.expand(n, n) - 2 * torch.mm(x, x.t())
         return dist
 
@@ -59,8 +59,8 @@ def pairwise_distance(features, query=None, gallery=None, metric=None):
     if metric is not None:
         x = metric.transform(x)
         y = metric.transform(y)
-    dist = torch.pow(x, 2).sum(1).expand(m, n) + \
-           torch.pow(y, 2).sum(1).expand(n, m).t()
+    dist = torch.pow(x, 2).sum(dim=1, keepdim=True).expand(m, n) + \
+           torch.pow(y, 2).sum(dim=1, keepdim=True).expand(n, m).t()
     dist.addmm_(1, -2, x, y.t())
     return dist
 

--- a/reid/loss/triplet.py
+++ b/reid/loss/triplet.py
@@ -14,7 +14,7 @@ class TripletLoss(nn.Module):
     def forward(self, inputs, targets):
         n = inputs.size(0)
         # Compute pairwise distance, replace by the official when merged
-        dist = torch.pow(inputs, 2).sum(1).expand(n, n)
+        dist = torch.pow(inputs, 2).sum(dim=1, keepdim=True).expand(n, n)
         dist = dist + dist.t()
         dist.addmm_(1, -2, inputs, inputs.t())
         dist = dist.clamp(min=1e-12).sqrt()  # for numerical stability
@@ -23,7 +23,7 @@ class TripletLoss(nn.Module):
         dist_ap, dist_an = [], []
         for i in range(n):
             dist_ap.append(dist[i][mask[i]].max())
-            dist_an.append(dist[i][1 - mask[i]].min())
+            dist_an.append(dist[i][mask[i] == 0].min())
         dist_ap = torch.cat(dist_ap)
         dist_an = torch.cat(dist_an)
         # Compute ranking hinge loss

--- a/reid/models/inception.py
+++ b/reid/models/inception.py
@@ -109,7 +109,7 @@ class InceptionNet(nn.Module):
             x = self.feat(x)
             x = self.feat_bn(x)
         if self.norm:
-            x = x / x.norm(2, 1).expand_as(x)
+            x = x / x.norm(p=2, dim=1, keepdim=True).expand_as(x)
         elif self.has_embedding:
             x = F.relu(x)
         if self.dropout > 0:

--- a/reid/models/resnet.py
+++ b/reid/models/resnet.py
@@ -78,7 +78,7 @@ class ResNet(nn.Module):
             x = self.feat(x)
             x = self.feat_bn(x)
         if self.norm:
-            x = x / x.norm(2, 1).expand_as(x)
+            x = x / x.norm(p=2, dim=1, keepdim=True).expand_as(x)
         elif self.has_embedding:
             x = F.relu(x)
         if self.dropout > 0:


### PR DESCRIPTION
This PR adapts current code to PyTorch v0.2, which has changed some APIs. OpenReID now requires PyTorch version >= 0.2.0.

This PR fixes #17, #18, #19.