### PR TITLE
add an option to save checkpoints at a specific epoch

### DIFF
--- a/examples/oim_loss.py
+++ b/examples/oim_loss.py
@@ -148,6 +148,8 @@ def main(args):
     for epoch in range(start_epoch, args.epochs):
         adjust_lr(epoch)
         trainer.train(epoch, train_loader, optimizer)
+        if epoch < args.start_save:
+            continue
         top1 = evaluator.evaluate(val_loader, dataset.val, dataset.val)
 
         is_best = top1 > best_top1
@@ -207,6 +209,8 @@ if __name__ == '__main__':
     parser.add_argument('--evaluate', action='store_true',
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=50)
+    parser.add_argument('--start_save', type=int, default=0,
+                        help="save checkpoints at specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning

--- a/examples/oim_loss.py
+++ b/examples/oim_loss.py
@@ -210,7 +210,7 @@ if __name__ == '__main__':
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=50)
     parser.add_argument('--start_save', type=int, default=0,
-                        help="save checkpoints at specific epoch")
+                        help="start saving checkpoints after specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning

--- a/examples/softmax_loss.py
+++ b/examples/softmax_loss.py
@@ -202,7 +202,7 @@ if __name__ == '__main__':
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=50)
     parser.add_argument('--start_save', type=int, default=0,
-                        help="save checkpoints at specific epoch")
+                        help="start saving checkpoints after specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning

--- a/examples/softmax_loss.py
+++ b/examples/softmax_loss.py
@@ -145,6 +145,8 @@ def main(args):
     for epoch in range(start_epoch, args.epochs):
         adjust_lr(epoch)
         trainer.train(epoch, train_loader, optimizer)
+        if epoch < args.start_save:
+            continue
         top1 = evaluator.evaluate(val_loader, dataset.val, dataset.val)
 
         is_best = top1 > best_top1
@@ -199,6 +201,8 @@ if __name__ == '__main__':
     parser.add_argument('--evaluate', action='store_true',
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=50)
+    parser.add_argument('--start_save', type=int, default=0,
+                        help="save checkpoints at specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning

--- a/examples/triplet_loss.py
+++ b/examples/triplet_loss.py
@@ -142,6 +142,8 @@ def main(args):
     for epoch in range(start_epoch, args.epochs):
         adjust_lr(epoch)
         trainer.train(epoch, train_loader, optimizer)
+        if epoch < args.start_save:
+            continue
         top1 = evaluator.evaluate(val_loader, dataset.val, dataset.val)
 
         is_best = top1 > best_top1
@@ -202,6 +204,8 @@ if __name__ == '__main__':
     parser.add_argument('--evaluate', action='store_true',
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=150)
+    parser.add_argument('--start_save', type=int, default=0,
+                        help="save checkpoints at specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning

--- a/examples/triplet_loss.py
+++ b/examples/triplet_loss.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
                         help="evaluation only")
     parser.add_argument('--epochs', type=int, default=150)
     parser.add_argument('--start_save', type=int, default=0,
-                        help="save checkpoints at specific epoch")
+                        help="start saving checkpoints after specific epoch")
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument('--print-freq', type=int, default=1)
     # metric learning


### PR DESCRIPTION
The best checkpoints rarely occurred in the first few epochs. So adding this option will reduce the trainning time.
For example:
```
python examples/triplet_loss.py -d market1501 -a resnet50 --combine-trainval --logs-dir examples/logs/triplet-loss/market1501-resnet50
```
and
```
python examples/triplet_loss.py --start_save 130 -d market1501 -a resnet50 --combine-trainval --logs-dir examples/logs/triplet-loss/market1501-resnet50
```
gives the same results. But the latter is faster. 
