### PR TITLE
Support for pytorch v0.3

### DIFF
--- a/reid/utils/data/transforms.py
+++ b/reid/utils/data/transforms.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
 from torchvision.transforms import *
+from PIL import Image
+import random
+import math
 
 
 class RectScale(object):


### PR DESCRIPTION
Pytorch has [released 0.3 version](https://github.com/pytorch/pytorch/releases/tag/v0.3.0) a few days ago.
We should import some packages explicitly in ` open-reid/reid/utils/data/transforms.py` under pytorch v0.3